### PR TITLE
Added option for channels as place to send notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tasty-Jaffa-cogs
+# Tasty Jaffa cogs
 These are a collection of cogs I have made on various requests. These cogs are intended for use with the open source discord bot "Red" https://github.com/Cog-Creators/Red-DiscordBot/
 
 ~ These cogs have been made by The Tasty Jaffa

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Tasty-Taffa-cogs
+# Tasty-Jaffa-cogs
 These are a collection of cogs I have made on various requests. These cogs are intended for use with the open source discord bot "Red" https://github.com/Cog-Creators/Red-DiscordBot/
 
 ~ These cogs have been made by The Tasty Jaffa

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
     "AUTHOR" : "The Tasty Jaffa",
-    "INSTALL_MSG" : "The Tasty Jaffa cogs, a collection of cogs - suggested by the community to get support join here - https://discord.gg/MbKwDGC",
+    "INSTALL_MSG" : "The Tasty Jaffa cogs, a mixture of cogs to help with various tasks - Make sure to join the `red - cog support` server and ask for support in the #support_othercogs channel -- For more information on the cogs, suuggestions and other projects you can find The Tasty Jaffa in his server [here](https://discord.gg/MbKwDGC)",
     "NAME" : "Tasty-Jaffa-cogs",
-    "SHORT" : "Collection of cogs requested by the community",
-    "DESCRIPTION" : "A collection of custom-made cogs made on the request of the community."
+    "SHORT" : "Collection of cogs requested and improved by the community",
+    "DESCRIPTION" : "A collection of cogs made for the community."
 }

--- a/rolenotifier/rolenotifier.py
+++ b/rolenotifier/rolenotifier.py
@@ -5,59 +5,108 @@ from .utils.dataIO import dataIO
 import os
 
 #requested by Freud
+#Improved thanks to the community!
 #programed by The Tasty Jaffa
 #Some help with gramma from Freud (and also testing it making sure it worked)
+
 
 class RoleNotifier:
     def __init__(self, bot):
         self.bot = bot
         self.settings = dataIO.load_json("data/Tasty/AutoRoleDM/settings.json")
+        # Checks the data in the file (ie updating or bot joined server when offline)
         for x in self.bot.servers:
             try:
-                print("Testing Values for settings.json in /Tatsy/AutoRoleDM")
-                self.settings[x.id]
-            except:
+                #to avoid breaking things, checks if it is in correct format
+                #NOTE: Only works when reloaded!
+                items = self.settings[x.id]
 
+                for key,value in items.items():
+                    if type(value) == type(dict()):
+                        continue
+
+                    self.settings[x.id][key] = {'MSG':value, 'CHANNEL':None}                   
+
+            except Exception as e:
+                print(e)
                 self.settings[x.id]={
                     }
+
         dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
-        
+    
+    #Checks if it needs to send a notification
     async def Role_Update_check(self, before, after):
 
         check_roles = [r for r in after.roles if r not in before.roles]
         for role in check_roles:
-            try: #Should catch index error (ie don't alert)
-                msg = self.settings[after.server.id][role.name] 
-                await self.bot.send_message(after, msg.format(role.name, after.server.name, after.mention, after.name))
-            except:
-                pass
-    
-    @commands.command(pass_context=True, name="AutoroleInfo")
+            if role.name in self.settings[after.server.id]:
+
+                #Sets the notification destination (channel or user)
+                if self.settings[after.server.id][role.name]['CHANNEL'] is not None:
+                    channel = self.settings[after.server.id][role.name]['CHANNEL']
+                    channel = self.bot.get_channel(channel)
+                else:
+                    channel = after
+
+                msg = self.settings[after.server.id][role.name]['MSG']
+                await self.bot.send_message(channel, msg.format(role.name, after.server.name, after.mention, after.name))
+
+    #General spesific help with the cog
+    @commands.command(pass_context=True, name="AutoRoleHelp")
     @checks.admin_or_permissions(manage_roles=True)
-    async def Notification_message_syntax_on_Tasty_Jaffa_cogs(self, ctx):
-        """Infomation on how to use [p]setroles. ~ Provides infomation on the syntax of what is sent and how to use it"""
-        em = Embed(tile="Infomation on how to use the notification system")
+    async def Notification_message_syntax_on_Tasty_Jaffa_cogs(self, ctx): # yes long name :)
+        """Provides infomation on the syntax on how to use this cog"""
+        em = Embed(tile="Infomation on how to use the notification system, use `[p]help` to find right comands")
         em.add_field(name="Use of `{0}`", value = "The name of the role that was gained", inline=True)
         em.add_field(name="Use of `{1}`", value = "The name of the server that the role was gained in", inline=True)
         em.add_field(name="Use of `{2}`", value = "Mentions the user who gained the role", inline=True)
         em.add_field(name="Use of `{3}`", value = "The name of the user who gained the role", inline=True)
-        em.add_field(name="How to enter the msg", value='Use speech marks `" "` around the msg -> example `[p]setroles Member "Well done {2}! You have gained {0}!"`', inline=False)
+        em.add_field(name="How to enter the msg", value='example `[p]setroles Member Well done {2}! You have gained {0}!`', inline=False)
         em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
         await self.bot.send_message(ctx.message.channel, embed=em)
     
     @commands.command(pass_context=True, name="setroles")
     @checks.admin_or_permissions(manage_roles=True)
-    async def set_roles(self, ctx, role_name:str, msg:str="Well done {2}! In {1} you have just gained {0} role"):
-        """Sets the notification message for roles, use speech marks for the [msg] paramater"""
-        await self.bot.send_message(ctx.message.channel, "This will dm a user with `{}` when then gain the `{}` role? \n\n __are you sure you want this? **y/n**__".format(msg, role_name))
+    async def set_roles(self, ctx, role_name:str, *, msg:str="Well done {2}! In {1} you have just gained {0} role"):
+        """For documentation of this command check the gitpage, use speech marks for the [msg] paramater"""
+
+        #Default settings
+        channel = None
+
+        if len(msg) > 1500:
+            await self.bot.send_message(ctx.message.channel, "Sorry the message is too long to continue with the process!")
+            return
+
+        await self.bot.send_message(ctx.message.channel, "Is this to be sent though a __**Direct message**__? **y/n**")
         response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
-        if response.content.lower() == 'y':
-            self.settings[ctx.message.server.id][role_name] = msg
+
+        #If it is to be Direct message
+        if 'y' in response.content.lower(): 
+            await self.bot.send_message(ctx.message.channel, "This will dm a user with `{}` when they gain the `{}` role? \n\n __are you sure you want this? **y/n**__".format(msg, role_name))
+            response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+        
+        #Get the channel if to be sent to a channel
+        else:
+            await self.bot.send_message(ctx.message.channel, "Please enter the **channelID** for which the notification should be sent?")
+            channel = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+            channel = self.bot.get_channel(channel.content)
+            
+            if channel is None:
+                await self.bot.send_message(ctx.message.channel, "No channel with this id was found, Aborting!!")
+                return
+            
+            await self.bot.send_message(ctx.message.channel, "This will send a message in the `{}` channel with `{}` when someone gains the `{}` role? \n\n __are you sure you want this? **y/n**__".format(channel.name, msg, role_name))
+            response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+            channel = channel.id
+
+        #Save notifcation
+        if 'y' in response.content.lower() :
+            self.settings[ctx.message.server.id][role_name] = {'MSG':msg, 'CHANNEL':channel}
             dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
-            await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention using `[p]AutoroleInfo`")
+            await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention on the git repo page!")
 
         else:
-            await self.bot.send_message(ctx.message.channel, "Aborted! -- Make sure to have a look at the documention using `[p]AutoroleInfo`!")
+            await self.bot.send_message(ctx.message.channel, "Aborted! -- Make sure to have a look at the documention on the git repo page!")
 
     @commands.command(pass_context=True, name="listroles")
     @checks.admin_or_permissions(manage_roles=True)
@@ -65,9 +114,13 @@ class RoleNotifier:
         """Lists all the roles that have been given/set a notification for in this server."""
 
         em = Embed(title="All roles and their notification messages")
-        for role_name, msg in self.settings[ctx.message.server.id].items():
-            em.add_field(name=role_name, value=msg, inline=True)
-        
+        for role_name, values in self.settings[ctx.message.server.id].items():
+            if values['CHANNEL'] is None:
+                em.add_field(name=role_name, value=values['MSG'], inline=True)
+
+            else:
+                em.add_field(name=role_name, value = values['MSG'] + "\n Channel: " + self.bot.get_channel(values['CHANNEL']).name, inline = True)
+
         em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
         await self.bot.send_message(ctx.message.channel, embed=em)
 
@@ -75,21 +128,24 @@ class RoleNotifier:
     @checks.admin_or_permissions(manage_roles=True)
     async def remove_roles(self, ctx, role_name):
         """Removes roles from notifications, use `[p]listroles` to find out what roles are set to be notifified"""
-        await self.bot.send_message("This will remove the `{}` role and people who gain this role will no longer be notified. \n\n__are you sure you want this? **y/n**__".format(msg, role_name))
+        await self.bot.send_message(ctx.message.channel, "This will remove the `{}` role and people who gain this role will no longer be notified. \n\n__are you sure you want this? **y/n**__".format(role_name))
         response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
-        if response.lower() == 'y':
+        if 'y' in response.lower():
             try:
-                del self.settings[ctx.message.server.id][role_name]
+                self.settings[ctx.message.server.id].pop(role_name)
                 dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
-                await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention using `[p]AutoroleInfo`!")
+                await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention on the git repo page!")
             except:
                 await self.bot.say("Woops! That role hasn't been set yet!")
         else:
-            await self.bot.send_message(ctx.message.channel, "Aborted! --  Make sure to have a look at the documention using `[p]AutoroleInfo`")
+            await self.bot.send_message(ctx.message.channel, "Aborted! --  Make sure to have a look at the documention on the git repo page!")
 
     async def server_join(self, server):
         self.settings[server.id]={
         }
+
+    async def server_leave(self,server):
+        self.settings.pop(server.id)
 
 def check_folders(): #Creates a folder
     if not os.path.exists("data/Tasty/AutoRoleDM"):
@@ -104,7 +160,14 @@ def check_files(): #Creates json files in the folder
 def setup(bot):
     check_folders()
     check_files()
-    n = RoleNotifier(bot)
-    bot.add_listener(n.Role_Update_check, 'on_member_update')
-    bot.add_listener(n.server_join, "on_server_join")
-    bot.add_cog(n)
+
+    this_cog = RoleNotifier(bot)
+    
+    #Data checking (ie cog was loaded or reloaded)
+
+    #Listeners
+    bot.add_listener(this_cog.Role_Update_check, 'on_member_update')
+    bot.add_listener(this_cog.server_join, "on_server_join")
+    bot.add_listener(this_cog.server_leave, "on_server_remove")
+    bot.add_cog(this_cog)
+

--- a/rolenotifier/rolenotifier.py
+++ b/rolenotifier/rolenotifier.py
@@ -52,23 +52,23 @@ class RoleNotifier:
                 await self.bot.send_message(channel, msg.format(role.name, after.server.name, after.mention, after.name))
 
     #General spesific help with the cog
-    @commands.command(pass_context=True, name="AutoRoleHelp")
+    @commands.group(pass_context=True, name="setnotifiroles")
     @checks.admin_or_permissions(manage_roles=True)
     async def Notification_message_syntax_on_Tasty_Jaffa_cogs(self, ctx): # yes long name :)
-        """Provides infomation on the syntax on how to use this cog"""
-        em = Embed(tile="Infomation on how to use the notification system, use `[p]help` to find right comands")
+        """Command group: Use with no sub command for infomation on the syntax on how to use this cog"""
+        em = Embed(tile="Infomation on how to use the notification system, use `[p]help setnotifiroles` to find right sub commands comands")
         em.add_field(name="Use of `{0}`", value = "The name of the role that was gained", inline=True)
         em.add_field(name="Use of `{1}`", value = "The name of the server that the role was gained in", inline=True)
         em.add_field(name="Use of `{2}`", value = "Mentions the user who gained the role", inline=True)
         em.add_field(name="Use of `{3}`", value = "The name of the user who gained the role", inline=True)
-        em.add_field(name="How to enter the msg", value='example `[p]setroles Member Well done {2}! You have gained {0}!`', inline=False)
+        em.add_field(name="How to enter the msg", value='example `[p]setnotifiroles add Member Well done {2}! You have gained {0}!`', inline=False)
         em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
         await self.bot.send_message(ctx.message.channel, embed=em)
     
-    @commands.command(pass_context=True, name="setroles")
+    @setnotifiroles.command(pass_context=True, name="add")
     @checks.admin_or_permissions(manage_roles=True)
     async def set_roles(self, ctx, role_name:str, *, msg:str="Well done {2}! In {1} you have just gained {0} role"):
-        """For documentation of this command check the gitpage, use speech marks for the [msg] paramater"""
+        """For infomation on this command use [p]setnotifiroles with no sub co, use speech marks for the [msg] paramater"""
 
         #Default settings
         channel = None
@@ -108,7 +108,7 @@ class RoleNotifier:
         else:
             await self.bot.send_message(ctx.message.channel, "Aborted! -- Make sure to have a look at the documention on the git repo page!")
 
-    @commands.command(pass_context=True, name="listroles")
+    @setnotifiroles.command(pass_context=True, name="list")
     @checks.admin_or_permissions(manage_roles=True)
     async def list_roles(self, ctx):
         """Lists all the roles that have been given/set a notification for in this server."""
@@ -124,7 +124,7 @@ class RoleNotifier:
         em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
         await self.bot.send_message(ctx.message.channel, embed=em)
 
-    @commands.command(name="removerole", pass_context=True)
+    @setnotifiroles.command(name="remove", pass_context=True)
     @checks.admin_or_permissions(manage_roles=True)
     async def remove_roles(self, ctx, role_name):
         """Removes roles from notifications, use `[p]listroles` to find out what roles are set to be notifified"""
@@ -145,7 +145,7 @@ class RoleNotifier:
         }
 
     async def server_leave(self,server):
-        self.settings.pop(server.id)
+        self.settings.remove(server.id)
 
 def check_folders(): #Creates a folder
     if not os.path.exists("data/Tasty/AutoRoleDM"):

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -2,7 +2,6 @@ import discord, logging, os, asyncio, datetime
 from discord.ext import commands
 from .utils.dataIO import dataIO
 from .utils import checks
-from __main__ import send_cmd_help
 
 #Created by The Tasty Jaffa
 #Requested by idlechatter
@@ -97,7 +96,8 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             
             em.set_author(name=ctx.message.server.name, icon_url=ctx.message.server.icon_url)
             em.set_footer(text="This cog can be found [here](https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/)")
-                    
+            
+            await self.bot.send_message(ctx.message.channel, embed=em)
 
     @VoiceSet.command(name="category", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -50,6 +50,7 @@ class TempVoice:
             info = ''.join('{}{}\n'.format(key, val) for key, val in self.settings[ctx.message.server.id].items())
             em = discord.Embed(title="Tempary voice channel settings", description="""voice [name]
 Creates a Voice channel named after the user who called it or by the optional parameter [name]
+*only works when mode = 2*
 
 channel <channel_id>
 Selects a voice channel which users can join to create a tempary voice channel (Applys to mode = 1 only)
@@ -61,7 +62,7 @@ role <role_name>
 Sets the role which can use the command to make a temporary voice channel -- example - [p]setvoice role autovoice
 
 type <mode_number>
-Sets the mode type for the server
+Sets the mode type for the server, defualts to 2.
 Mode = 1, Use of a Channel. `[p]setvoice type 1`
 Mode = 2, Use of a command. `[p]setvoice type 2`
 
@@ -81,19 +82,21 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             em.add_field(name="Type", value=rep, inline=False)
             
             try:
-                em.add_field(name="channel",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['channel']).name, inline=False)
+                em.add_field(name="Channel",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['channel']).name, inline=False)
             except:
-                em.add_field(name="channel",value = "None", inline=False)
+                em.add_field(name="Channel",value = "None", inline=False)
             
             try:
-                em.add_field(name="category",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['category']).name, inline=False)
+                em.add_field(name="Category",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['category']).name, inline=False)
             except:
-                em.add_field(name="category",value = "None", inline=False)
+                em.add_field(name="Category",value = "None", inline=False)
 
             em.add_field(name="Role", value = get_role(ctx, self.settings[ctx.message.server.id]['role']), inline=False)
             
+            em.add_field(name="Name", value = self.settings[ctx.message.server.id]['defualt_name'])
+            
             em.set_author(name=ctx.message.server.name, icon_url=ctx.message.server.icon_url)
-            em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
+            em.set_footer(text="This cog can be found [here](https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/)")
                     
             await self.bot.send_message(ctx.message.channel, embed=em)
 

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -361,9 +361,6 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json",self.check_empty)# saves new list
             await asyncio.sleep(DELAY)
 
-        await self.bot.send_message(discord.AppInfo.owner, "Channels will no longer be deleted! An issue has ocurred. some INFO: `self.check_empty: {0} | self.bot.get_cog: {1}`".format(self.check_empty, self.bot.get_cog("TempVoice")))
-        #Some instances have issues here (not sure why still)
-
 def check_folders(): #Creates a folder
     if not os.path.exists("data/Tasty/TempVoice"):
         print("Creating data/Tasty/TempVoice folder...")

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -30,6 +30,7 @@ class TempVoice:
                     'role':None,
                     'channel':None,
                     'type':False,
+                    'category':None,
                     'defualt_name':"{user.nick}"
                     }
             
@@ -37,6 +38,9 @@ class TempVoice:
             if 'defualt_name' not in self.settings[x.id]:
                 self.settings[x.id]['defualt_name']="{user.nick}"
             
+            if 'category' not in self.settings[x.id]:
+                self.settings[x.id]['category'] = None
+
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
     
     #Cog settings
@@ -237,7 +241,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             channel = await self.bot.create_channel(ctx.message.server, name, perms, type=discord.ChannelType.voice)#creates a channel          
             
             #If a category has been set 
-            if self.settings[channel.server.id]['category'] is not none:
+            if self.settings[channel.server.id]['category'] is not None:
                 await self.move_channel_to_category(channel.id, self.settings[channel.server.id]['category'])
                 
             self.check_empty.append(channel.id) #Multidimentional list

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -31,8 +31,13 @@ class TempVoice:
                     'role':None,
                     'channel':None,
                     'type':False,
+                    'defualt_name':"{user.nick}"
                     }
-
+            
+            #Avoid breaking things when people update
+            if 'defualt_name' not in self.settings[x.id]:
+                self.settings[x.id]['defualt_name']="{user.nick}"
+            
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
     
     #Cog settings
@@ -59,6 +64,12 @@ type <mode_number>
 Sets the mode type for the server
 Mode = 1, Use of a Channel. `[p]setvoice type 1`
 Mode = 2, Use of a command. `[p]setvoice type 2`
+
+name <defualt_channel_name>
+Sets the defualt channel name format to be used when greating a channel
+Use {user.name} for the users name
+Use {user.game} for the users current game they are playing
+Use {user.nick} for the users Nickname in the server
 
 Also make sure I have "move members" and "manage channels" permissions! """, colour=0xff0000)
             
@@ -180,12 +191,12 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
     
     @VoiceSet.command(name="name", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_default(self,ctx,*,defualt_name="{user.name}")
+    async def voice_set_default(self,ctx,*,defualt_name="{user.nick}")
         """sets the default channel name, resets with no parameters
         Allows for {user.name} for their name
         {user.game} for their currently playing status
         Many other values of user can be used as well"""
-        self.settings[ctx.message.server]['defualt_name'] = defualt_name
+        self.settings[ctx.message.server.id]['defualt_name'] = defualt_name
         await self.say("Default channel name set to `{0}`!".format(defualt_name))
     
     #Voice command
@@ -199,7 +210,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             return
 
         if name =='': #Tests if no name was passed
-            name = self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
+            name = self.settings[ctx.message.server.id]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
 
         server_role = self.settings[ctx.message.server.id]['role']
         if server_role is not None:
@@ -268,6 +279,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             'role':None,
             'channel':None,
             'type':False,
+            'defualt_name':"{user.nick}"
             }
 
     async def AutoTempVoice(self, before, user): #Is called when Someone joins the voice channel - Listener

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -2,6 +2,7 @@ import discord, logging, os, asyncio, datetime
 from discord.ext import commands
 from .utils.dataIO import dataIO
 from .utils import checks
+from __main__ import send_cmd_help
 
 #Created by The Tasty Jaffa
 #Requested by idlechatter

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -207,7 +207,11 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             perms = discord.PermissionOverwrite(mute_members=True, deafen_members=True, manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=ctx.message.author, overwrite=perms)#Sets the channel permissions for the person who sent the message
             channel = await self.bot.create_channel(ctx.message.server, name, perms, type=discord.ChannelType.voice)#creates a channel          
-            await self.move_channel_to_category(channel.id, self.settings[channel.server.id]['category'])
+            
+            #If a category has been set 
+            if self.settings[channel.server.id]['category'] is not none:
+                await self.move_channel_to_category(channel.id, self.settings[channel.server.id]['category'])
+                
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file
             return

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -329,7 +329,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
 
-            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[user.voice_channel.server.id]['defualt_name'].format(user=user), perms, type=discord.ChannelType.voice)#creates a channel           
+            channel = await self.bot.create_channel(user.voice_channel.server, name, perms, type=discord.ChannelType.voice)#creates a channel           
             
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -45,16 +45,21 @@ class TempVoice:
             info = ''.join('{}{}\n'.format(key, val) for key, val in self.settings[ctx.message.server.id].items())
             em = discord.Embed(title="Tempary voice channel settings", description="""voice [name]
 Creates a Voice channel named after the user who called it or by the optional parameter [name]
+
 channel <channel_id>
 Selects a voice channel which users can join to create a tempary voice channel (Applys to mode = 1 only)
+
 category <category_id>
-which category channels should be created under (Applys to mode = 2 only)
+Sets the category channels should be created under (Applys to mode = 2 only)
+
 role <role_name>
 Sets the role which can use the command to make a temporary voice channel -- example - [p]setvoice role autovoice
+
 type <mode_number>
 Sets the mode type for the server
 Mode = 1, Use of a Channel. `[p]setvoice type 1`
 Mode = 2, Use of a command. `[p]setvoice type 2`
+
 Also make sure I have "move members" and "manage channels" permissions! """, colour=0xff0000)
             
             if self.settings[ctx.message.server.id]["type"] is True:
@@ -84,7 +89,15 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
     @VoiceSet.command(name="category", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
     async def voice_set_category(self, ctx, category_id:str):
-        """Enter **Category** id - Sets the category that channels will be created under"""
+        """Enter **Category** id - Sets the category that channels will be created under (enter None to remove)"""
+        if not category_id.isdigit():
+
+            await self.bot.send_message(ctx.message.channel, "Category removed!")
+
+            self.settings[ctx.message.server.id]['category'] = None
+            dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
+            return
+
         category = self.bot.get_channel(category_id)
 
         #If it couldn't get the channel
@@ -108,13 +121,19 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
         """Enter **Voice** channel id to set the channel to join to make a new sub channel """
         
         channel = self.bot.get_channel(channel_id)
+
+        #Does this channel exist?
         if channel is None:
             channel = discord.utils.get(ctx.message.server.channels, name=channel_id, type=discord.ChannelType.voice)
             #Makes sure it can find the channel
             if channel is None:
-                await self.bot.send_message(ctx.message.channel, "That channel was not found")
+                await self.bot.send_message(ctx.message.channel, "That channel was not found.")
                 return
-            
+
+        if channel.type is not discord.ChannelType.voice: #Check if voice channel
+            await self.bot.send_message(ctx.message.channel, "That is not a voice channel.")
+            return
+
         await self.bot.send_message(ctx.message.channel, "Channel set!")    
         self.settings[ctx.message.server.id]['channel']=channel.id
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -34,7 +34,8 @@ class TempVoice:
                     }
 
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-
+    
+    #Cog settings
     @commands.group(name="setvoice", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
     async def VoiceSet(self, ctx):
@@ -135,6 +136,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
 
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)                  
     
+    #Voice command
     @commands.command(pass_context=True)
     @commands.cooldown(1, 60, commands.BucketType.user)
     async def voice(self, ctx, *, name:str=''): #actual command
@@ -173,7 +175,32 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             print("=================")
 
             await self.bot.send_message(ctx.message.channel, "An error occured - check logs")
+    
+    #Category implimentaion
+    async def channel_to_category(self, channel_in_category_id, channel_to_move_id):
+        category_id = await self.bot.http.request(
+            discord.http.Route(
+                'GET', '/channels/{}'.format(channel_in_category_id)
+            )
+        ) #Gets The "channel_in_category" Categories ID
 
+        category_id = category_id["parent_id"]
+
+        channel = await self.bot.http.request(
+            discord.http.Route(
+                'GET', '/channels/{}'.format(channel_to_move_id)
+            )
+        ) #gets the channel we want to move data (as json) -- Could be improved further
+
+        channel["parent_id"] = category_id #Updates with the category info that we want
+
+        await self.bot.http.request(
+            discord.http.Route(
+                'PATCH', '/channels/{}'.format(channel_to_move_id)
+            ), json = channel #uses PATCH method to update the channel
+        )
+    
+    #Lister defs
     async def server_join(self, server):
         self.settings[server.id]={
             'role':None,

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -2,7 +2,6 @@ import discord, logging, os, asyncio, datetime
 from discord.ext import commands
 from .utils.dataIO import dataIO
 from .utils import checks
-from __main__ import send_cmd_help
 
 #Created by The Tasty Jaffa
 #Requested by idlechatter
@@ -98,7 +97,6 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             em.set_author(name=ctx.message.server.name, icon_url=ctx.message.server.icon_url)
             em.set_footer(text="This cog can be found [here](https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/)")
                     
-            await self.bot.send_message(ctx.message.channel, embed=em)
 
     @VoiceSet.command(name="category", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
@@ -316,7 +314,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
 
-            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author), perms, type=discord.ChannelType.voice)#creates a channel           
+            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=user), perms, type=discord.ChannelType.voice)#creates a channel           
             
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -1,409 +1,200 @@
-import discord, logging, os, asyncio, datetime
 from discord.ext import commands
-from .utils.dataIO import dataIO
+from discord import Embed
+from discord import Forbidden
 from .utils import checks
+from .utils.dataIO import dataIO
+import os
 
-#Created by The Tasty Jaffa
-#Requested by idlechatter
-#Thanks to Tobotimus for helping with the listener function
+#requested by Freud
+#Improved thanks to the community!
+#programed by The Tasty Jaffa
+#Some help with gramma from Freud (and also testing it making sure it worked)
 
-def get_role(ctx, role_id):
-    roles = set(ctx.message.server.roles)
-    for role in roles:
-        if role.id == role_id:
-            return role
-    return None
 
-class TempVoice:
+class RoleNotifier:
     def __init__(self, bot):
         self.bot = bot
-        self.check_empty = dataIO.load_json("data/Tasty/TempVoice/VoiceChannel.json")
-        self.settings = dataIO.load_json("data/Tasty/TempVoice/settings.json")
-        
-        print("Testing Values for settings.json in /Tatsy/TempVoice")
+        self.settings = dataIO.load_json("data/Tasty/AutoRoleDM/settings.json")
+        # Checks the data in the file (ie updating or bot joined server when offline)
         for x in self.bot.servers:
             try:
-                self.settings[x.id]
-            except:
+                #to avoid breaking things, checks if it is in correct format
+                items = self.settings[x.id]
 
+                for key,value in items.items():
+                    if type(value) == type(dict()):
+                        continue
+
+                    self.settings[x.id][key] = {'MSG':value, 'CHANNEL':None}                   
+
+            except Exception as e:
                 self.settings[x.id]={
-                    'role':None,
-                    'channel':None,
-                    'type':False,
-                    'category':None,
-                    'defualt_name':"{user.nick}"
                     }
-            
-            #Avoid breaking things when people update
-            if 'defualt_name' not in self.settings[x.id]:
-                self.settings[x.id]['defualt_name']="{user.nick}"
-            
-            if 'category' not in self.settings[x.id]:
-                self.settings[x.id]['category'] = None
 
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-    
-    #Cog settings
-    @commands.group(name="setvoice", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def VoiceSet(self, ctx):
-        """Changes the settings for this cog, use with no sub command to get infomation on the cog, and current setings"""
+        dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
 
+    #Data validity checker (if joined server when bot was down)
+    async def data_check(self): #When servers are aviable
+        for x in self.bot.servers:
+            try:
+                #to avoid breaking things, checks if it is in correct format
+                items = self.settings[x.id]
+
+                for key,value in items.items():
+                    if type(value) == type(dict()):
+                        continue
+
+                    self.settings[x.id][key] = {'MSG':value, 'CHANNEL':None}                   
+
+            except Exception as e:
+                self.settings[x.id]={
+                    }
+
+        dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
+
+    #Checks if it needs to send a notification
+    async def Role_Update_check(self, before, after):
+
+        check_roles = [r for r in after.roles if r not in before.roles]
+        for role in check_roles:
+            if role.name in self.settings[after.server.id]:
+
+                #Sets the notification destination (channel or user)
+                if self.settings[after.server.id][role.name]['CHANNEL'] is not None:
+                    channel = self.settings[after.server.id][role.name]['CHANNEL']
+                    channel = self.bot.get_channel(channel)
+                else:
+                    channel = after
+
+                try:
+                    msg = self.settings[after.server.id][role.name]['MSG']
+                    await self.bot.send_message(channel, msg.format(role.name, after.server.name, after.mention, after.name))
+                
+                except Forbidden:
+                    await self.bot.send_message(after.server.owner, "I could not send a message to {0}. \n I either cannot send messsage to the channel or the user does not accept Direct messages.".format(channel.name))
+
+    #General spesific help with the cog
+    @commands.group(pass_context=True, name="setroles")
+    @checks.admin_or_permissions(manage_roles=True)
+    async def set_notification_roles(self, ctx): 
+        """Command group: Use with no sub command for infomation on the syntax on how to use this cog"""
+        
         if ctx.invoked_subcommand is None:
-            info = ''.join('{}{}\n'.format(key, val) for key, val in self.settings[ctx.message.server.id].items())
-            em = discord.Embed(title="Tempary voice channel settings", description="""voice [name]
-Creates a Voice channel named after the user who called it or by the optional parameter [name]
-*only works when mode = 2*
-
-channel <channel_id>
-Selects a voice channel which users can join to create a tempary voice channel (Applys to mode = 1 only)
-
-category <category_id>
-Sets the category channels should be created under (Applys to mode = 2 only)
-
-role <role_name>
-Sets the role which can use the command to make a temporary voice channel -- example - [p]setvoice role autovoice
-
-type <mode_number>
-Sets the mode type for the server, defualts to 2.
-Mode = 1, Use of a Channel. `[p]setvoice type 1`
-Mode = 2, Use of a command. `[p]setvoice type 2`
-
-name <defualt_channel_name>
-Sets the defualt channel name format to be used when greating a channel
-Use {user.name} for the users name
-Use {user.game} for the users current game they are playing
-Use {user.nick} for the users Nickname in the server
-
-Also make sure I have "move members" and "manage channels" permissions! """, colour=0xff0000)
-            
-            if self.settings[ctx.message.server.id]["type"] is True:
-                rep = "Use of a Channel (mode = 1)"
-            else:
-                rep = "Use of a Command (mode = 2)"
-                
-            em.add_field(name="Type", value=rep, inline=False)
-            
-            try:
-                em.add_field(name="Channel",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['channel']).name, inline=False)
-            except:
-                em.add_field(name="Channel",value = "None", inline=False)
-            
-            try:
-                em.add_field(name="Category",value = ctx.message.server.get_channel(self.settings[ctx.message.server.id]['category']).name, inline=False)
-            except:
-                em.add_field(name="Category",value = "None", inline=False)
-
-            em.add_field(name="Role", value = get_role(ctx, self.settings[ctx.message.server.id]['role']), inline=False)
-            
-            em.add_field(name="Name", value = self.settings[ctx.message.server.id]['defualt_name'])
-            
-            em.set_author(name=ctx.message.server.name, icon_url=ctx.message.server.icon_url)
-            em.set_footer(text="This cog can be found [here](https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/)")
-            
+            em = Embed(tile="Infomation on how to use the notification system, use `[p]help setnotifiroles` to find right sub commands comands")
+            em.add_field(name="Use of `{0}`", value = "The name of the role that was gained", inline=False)
+            em.add_field(name="Use of `{1}`", value = "The name of the server that the role was gained in", inline=False)
+            em.add_field(name="Use of `{2}`", value = "Mentions the user who gained the role", inline=False)
+            em.add_field(name="Use of `{3}`", value = "The name of the user who gained the role", inline=False)
+            em.add_field(name="How to enter the msg", value='example `[p]setroles add Member Well done {2}! You have gained {0}!`', inline=False)
+            em.add_field(name="Subcommands", value='Use `[p]help setroles` to find out all the subcommands and what they do!', inline=False)
+            em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
             await self.bot.send_message(ctx.message.channel, embed=em)
-
-    @VoiceSet.command(name="category", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_category(self, ctx, category_id:str):
-        """Enter **Category** id - Sets the category that channels will be created under (enter None to remove)"""
-        if not category_id.isdigit():
-
-            await self.bot.send_message(ctx.message.channel, "Category removed!")
-
-            self.settings[ctx.message.server.id]['category'] = None
-            dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-            return
-
-        category = self.bot.get_channel(category_id)
-
-        #If it couldn't get the channel
-        if category is None:
-            await self.bot.send_message(ctx.message.channel, "Woops! That its not a valid ID (or there was an issue with finding the channel)! Please make sure that you use the command with the id of a category.")
-            return
-
-        #Check that this is a category
-        if category.type != 4:
-            await self.bot.send_message(ctx.message.channel, "Woops! That its not a category! Please make sure that you use the command with the id of a category.")
-            return
-        
-        await self.bot.send_message(ctx.message.channel, "Category set as {0}! New channels will be created here if a command is used".format(category.name))
-
-        self.settings[ctx.message.server.id]['category'] = category_id
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-
-    @VoiceSet.command(name="channel", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_channel(self, ctx, channel_id:str):
-        """Enter **Voice** channel id to set the channel to join to make a new sub channel """
-        
-        channel = self.bot.get_channel(channel_id)
-
-        #Does this channel exist?
-        if channel is None:
-            channel = discord.utils.get(ctx.message.server.channels, name=channel_id, type=discord.ChannelType.voice)
-            #Makes sure it can find the channel
-            if channel is None:
-                await self.bot.send_message(ctx.message.channel, "That channel was not found.")
-                return
-
-        if channel.type is not discord.ChannelType.voice: #Check if voice channel
-            await self.bot.send_message(ctx.message.channel, "That is not a voice channel.")
-            return
-
-        await self.bot.send_message(ctx.message.channel, "Channel set!")    
-        self.settings[ctx.message.server.id]['channel']=channel.id
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-
-    @VoiceSet.command(name="role", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_role(self, ctx, role_name:str=""):
-        """sets the required role to use the [p]voice command (leave blank for no role)"""
     
-        role = discord.utils.get(ctx.message.server.roles, name=role_name)
+    @set_notification_roles.command(pass_context=True, name="add")
+    @checks.admin_or_permissions(manage_roles=True)
+    async def set_roles(self, ctx, role_name:str, *, msg:str="Well done {2}! In {1} you have just gained {0} role"):
+        """Adds an alert for a role - For infomation on this command use `[p]setroles`"""
 
-        if role_name == "":
-            await self.bot.send_message(ctx.message.channel, "The requirement of having a role has been removed!")
-            self.settings[ctx.message.server.id]['role'] = None
-            dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
+        #Default settings
+        channel = None
+
+        if len(msg) > 1500:
+            await self.bot.send_message(ctx.message.channel, "Sorry the message is too long to continue with the process!")
             return
 
-        if role is None:
-            await self.bot.send_message(ctx.message.channel, "Sorry but that role could not be found")
-            return
-        
-        await self.bot.send_message(ctx.message.channel, "Role set!")
-        self.settings[ctx.message.server.id]['role'] = role.id
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-            
-    @VoiceSet.command(name="type", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_type(self, ctx, voice_mode:int):
-        """Sets the Voice channel creation type - [2] = use of command - [1] = Use of channel"""
-        
-        if voice_mode == 2:
-            self.settings[ctx.message.server.id]['type']=False
+        await self.bot.send_message(ctx.message.channel, "Is this to be sent though a __**Direct message**__? **y/n**")
+        response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
 
-            await self.bot.say("Mode changed to use of a command `[p]voice` [Mode = 2]")
-            
-        elif voice_mode == 1:
-            self.settings[ctx.message.server.id]['type']=True
-            await self.bot.say("Mode changed to use of a channel `Join the set channel` [Mode = 1]")
-            
+        #If it is to be Direct message
+        if 'y' in response.content.lower(): 
+            await self.bot.send_message(ctx.message.channel, "This will dm a user with `{}` when they gain the `{}` role? \n\n __are you sure you want this? **y/n**__".format(msg, role_name))
+            response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+        
+        #Get the channel if to be sent to a channel
         else:
-            await self.bot.send_message(ctx.message.channel, "Sorry that's not a valid type")
+            await self.bot.send_message(ctx.message.channel, "Please enter the **channelID** for which the notification should be sent?")
+            channel = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+            channel = self.bot.get_channel(channel.content)
+            
+            if channel is None:
+                await self.bot.send_message(ctx.message.channel, "No channel with this id was found, Aborting!!")
+                return
+            
+            await self.bot.send_message(ctx.message.channel, "This will send a message in the `{}` channel with `{}` when someone gains the `{}` role? \n\n __are you sure you want this? **y/n**__".format(channel.name, msg, role_name))
+            response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+            channel = channel.id
 
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)                  
-    
-    @VoiceSet.command(name="name", pass_context=True)
-    @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_default(self,ctx,*,defualt_name:str="{user.nick}"):
-        """sets the default channel name, resets with no parameters"""
-        self.settings[ctx.message.server.id]['defualt_name'] = defualt_name
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
-        await self.bot.say("Default channel name set to `{0}`!".format(defualt_name))
-    
-    #Voice command
-    @commands.command(pass_context=True)
-    @commands.cooldown(1, 60, commands.BucketType.user)
-    async def voice(self, ctx, *, name:str=''): #actual command
-        """Creates a voice channel use opptional argument <name> to spesify the name of the channel, Use `" "` around the name of the channel"""
+        #Save notifcation
+        if 'y' in response.content.lower() :
+            self.settings[ctx.message.server.id][role_name] = {'MSG':msg, 'CHANNEL':channel}
+            dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
+            await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention on the git repo page!")
 
-        #Checks the mode (type = True (therefore mode = [1])
-        if self.settings[ctx.message.server.id]['type'] != False:
-            return
+        else:
+            await self.bot.send_message(ctx.message.channel, "Aborted! -- Make sure to have a look at the documention on the git repo page!")
 
-        if name =='': #Tests if no name was passed
-            if ctx.message.author.nick is not None:
-                name = self.settings[ctx.message.server.id]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
+    @set_notification_roles.command(pass_context=True, name="list")
+    @checks.admin_or_permissions(manage_roles=True)
+    async def list_roles(self, ctx):
+        """Lists all the roles that have been given/set a notification for in this server."""
 
-            #If they do not have a nickname
+        em = Embed(title="All roles and their notification messages")
+        for role_name, values in self.settings[ctx.message.server.id].items():
+            if values['CHANNEL'] is None:
+                em.add_field(name=role_name, value=values['MSG'], inline=True)
+
             else:
-                name = self.settings[ctx.message.server.id]['defualt_name'].replace("nick}","name}").format(user=ctx.message.author) #Sets it to the defualt name
+                em.add_field(name=role_name, value = values['MSG'] + "\n Channel: " + self.bot.get_channel(values['CHANNEL']).name, inline = True)
 
-        name = name.replace("None", "Nothing") #Replaces "None" so that channel name reads better
+        em.set_footer(text="This cog can be found here - https://github.com/The-Tasty-Jaffa/Tasty-Jaffa-cogs/")
+        await self.bot.send_message(ctx.message.channel, embed=em)
 
-        server_role = self.settings[ctx.message.server.id]['role']
-        if server_role is not None:
-            for role in set(ctx.message.author.roles):
-                if role.id == server_role:
-                    break # If role is found
-                    
-            else: #If we didn't break out of the loop then the user does not have the right role      
-                await self.bot.say("Sorry but you are not permited to use that command! A role is needed.")
-                return # If role is found breaks loop - else statement isn't executed.
+    @set_notification_roles.command(name="remove", pass_context=True)
+    @checks.admin_or_permissions(manage_roles=True)
+    async def remove_roles(self, ctx, role_name):
+        """Removes roles from notifications, use `[p]listroles` to find out what roles are set to be notifified"""
+        await self.bot.send_message(ctx.message.channel, "This will remove the `{}` role and people who gain this role will no longer be notified. \n\n__are you sure you want this? **y/n**__".format(role_name))
+        response = await self.bot.wait_for_message(channel = ctx.message.channel, author = ctx.message.author)
+        if 'y' in response.lower():
+            try:
+                self.settings[ctx.message.server.id].pop(role_name)
+                dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", self.settings)
+                await self.bot.send_message(ctx.message.channel, "Saved! -- Make sure to have a look at the documention on the git repo page!")
+            except:
+                await self.bot.say("Woops! That role hasn't been set yet!")
+        else:
+            await self.bot.send_message(ctx.message.channel, "Aborted! --  Make sure to have a look at the documention on the git repo page!")
 
-        
-        #If all the requirements are met
-        try:
-            perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
-            perms = discord.ChannelPermissions(target=ctx.message.author, overwrite=perms)#Sets the channel permissions for the person who sent the message
-            channel = await self.bot.create_channel(ctx.message.server, name, perms, type=discord.ChannelType.voice)#creates a channel          
-            
-            #If a category has been set 
-            if self.settings[channel.server.id]['category'] is not None:
-                await self.move_channel_to_category(channel.id, self.settings[channel.server.id]['category'])
-                
-            self.check_empty.append(channel.id) #Multidimentional list
-            dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file
-            return
-
-        except discord.Forbidden:
-            await self.bot.send_message(ctx.message.channel, "I don't have the right perrmissions for that! (I need to be able to manage channels)")
-            
-        except Exception as e: # if something else happens such as it's not connected or a file has been messed with and so doesn't show an error in discord channel
-            print("=================")
-            print(e)
-            print("=================")
-
-            await self.bot.send_message(ctx.message.channel, "An error occured - check logs")
-    
-    #Category implimentaion
-    async def channel_to_category(self, channel_in_category_id, channel_to_move_id):
-        channel_in_category = await self.bot.http.request(
-            discord.http.Route(
-                'GET', '/channels/{}'.format(channel_in_category_id)
-            )
-        ) #Gets The "channel_in_category" Categories ID
-
-        await self.move_channel_to_category(channel_to_move_id, channel_in_category["parent_id"])
-
-    async def move_channel_to_category(self, channel_to_move_id, category_id):
-
-        channel = await self.bot.http.request(
-            discord.http.Route(
-                'GET', '/channels/{}'.format(channel_to_move_id)
-            )
-        ) #gets the channel we want to move data (as json) -- Could be improved further
-
-        channel["parent_id"] = category_id #Updates with the category info that we want
-
-        await self.bot.http.request(
-            discord.http.Route(
-                'PATCH', '/channels/{}'.format(channel_to_move_id)
-            ), json = channel #uses PATCH method to update the channel
-        )
-    
-    #Lister defs
     async def server_join(self, server):
         self.settings[server.id]={
-            'role':None,
-            'channel':None,
-            'type':False,
-            'category': None,
-            'defualt_name':"{user.nick}"
-            }
+        }
 
-    async def AutoTempVoice(self, before, user): #Is called when Someone joins the voice channel - Listener
-        """Automaticly checks the voice channel for users and makes a channel for them"""
-        
-        # I cannot have any returns here so channels will be created
-        if before.voice_channel is not None:
-            # Did they come from a channel? 
+    async def server_leave(self,server):
+        self.settings.remove(server.id)
 
-            if before.voice_channel.id in self.check_empty:
-                #Was the channel they where in a tempary channel?
+def check_folders(): #Creates a folder, if it doesn't exist
+    if not os.path.exists("data/Tasty/AutoRoleDM"):
+        print("Creating data/Tasty/AutoRoleDM folder...")
+        os.makedirs("data/Tasty/AutoRoleDM")
 
-                if len(before.voice_channel.voice_members) == 0: 
-                    # How many people are in the channel?
-                    # if zero => empty. Therefore, remove the channel
-                    await self.bot.delete_channel(self.bot.get_channel(before.voice_channel.id))
-                    self.check_empty.remove(before.voice_channel.id)
-
-        if user.voice_channel is None: # Are they in a channel right now?
-            return
-        
-        if self.settings[user.voice_channel.server.id]['type']!=True:
-            return
-
-        try:
-            if self.settings[user.voice_channel.server.id]['channel']!=user.voice_channel.id:
-                return
-            
-            #set the channel name
-            if user.nick is not None:
-                name = self.settings[user.voice_channel.server.id]['defualt_name'].format(user=user) #Sets it to the defualt name for the server
-
-            #If they do not have a nickname
-            else:
-                name = self.settings[user.voice_channel.server.id]['defualt_name'].replace("nick}","name}").format(user=user) #Sets it to the defualt name
-
-            name = name.replace("None", "Nothing") #Replaces "None" so that channel name reads better
-            
-            position = user.voice_channel.position
-            perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
-            perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
-
-            channel = await self.bot.create_channel(user.voice_channel.server, name, perms, type=discord.ChannelType.voice)#creates a channel           
-            
-            self.check_empty.append(channel.id) #Multidimentional list
-            dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file
-
-            await self.channel_to_category(user.voice_channel.id, channel.id) #puts channel into the right category                
-            await self.bot.move_member(user, channel)
-            await self.bot.move_channel(channel, position+1)
-            
-        except discord.Forbidden:
-            await self.bot.send_message(user.server.owner, "I need the proper permissions! I was unable to create a new channel. (Move members, Manage channels)")
-
-    async def voice_check(self): #Loops around until channel is empty
-        DELAY = 60 #Delay in seconds
-        
-        while self == self.bot.get_cog("TempVoice"): #While bot is online/cog is loaded
-
-            Channels_to_remove = [] # To not looping over a list that you are modifiying
-            for channel_id in self.check_empty:
-
-                if self.bot.is_logged_in is not True: # So it doesn't go "Oh this channel doesn't exist" (becuase the bot isn't online/logged on)
-                    continue
-                
-                current = self.bot.get_channel(channel_id)
-
-                if current is None: # if channel doesn't exist
-                    Channels_to_remove.append(channel_id)
-                    continue
-
-                if len(current.voice_members) != 0: #Is the channel Empty (returns empty list if empty) - If no channel - attribute error
-                    continue
-
-                if datetime.datetime.today() - datetime.timedelta(seconds=30) < current.created_at:
-                    continue
-                
-                await self.bot.delete_channel(current)
-                Channels_to_remove.append(channel_id) #Adds it to a list for removall
-                
-                await asyncio.sleep(0.5)
-
-            for channel_id in Channels_to_remove:
-                self.check_empty.remove(channel_id)
-
-            dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json",self.check_empty)# saves new list
-            await asyncio.sleep(DELAY)
-
-def check_folders(): #Creates a folder
-    if not os.path.exists("data/Tasty/TempVoice"):
-        print("Creating data/Tasty/TempVoice folder...")
-        os.makedirs("data/Tasty/TempVoice")
-
-def check_files(): #Creates json files in the folder
-    if not dataIO.is_valid_json("data/Tasty/TempVoice/VoiceChannel.json"):
-        print("Creating empty VoiceChannel.json...")
-        dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", [])
-
-    if not dataIO.is_valid_json("data/Tasty/TempVoice/settings.json"):
+def check_files(): #Creates json files in the folder, if it doesn't exist
+    if not dataIO.is_valid_json("data/Tasty/AutoRoleDM/settings.json"):
         print("Creating empty settings.json...")    
-        dataIO.save_json("data/Tasty/TempVoice/settings.json", {})
-
+        dataIO.save_json("data/Tasty/AutoRoleDM/settings.json", {})
+  
 def setup(bot):
     check_folders()
     check_files()
 
-    n = TempVoice(bot)
+    this_cog = RoleNotifier(bot)
+    
+    #Data checking (ie cog was loaded or reloaded)
 
-    loop = asyncio.get_event_loop()
-    loop.create_task(n.voice_check())
+    #Listeners
+    bot.add_listener(this_cog.Role_Update_check, 'on_member_update')
+    bot.add_listener(this_cog.server_join, "on_server_join")
+    bot.add_listener(this_cog.server_leave, "on_server_remove")
+    bot.add_listener(this_cog.data_check, "on_ready")
 
-    bot.add_listener(n.AutoTempVoice, 'on_voice_state_update') #Thankyou to Tobotimus for giving a simple example on listeners
-    bot.add_listener(n.server_join, "on_server_join")
+    bot.add_cog(this_cog)
 
-    bot.add_cog(n)

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -191,7 +191,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
     
     @VoiceSet.command(name="name", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_default(self,ctx,*,defualt_name:str="{user.nick}")
+    async def voice_set_default(self,ctx,*,defualt_name:str="{user.nick}"):
         """sets the default channel name, resets with no parameters
         Allows for {user.name} for their name
         {user.game} for their currently playing status

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -200,7 +200,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
         {user.game} for their currently playing status
         Many other values of user can be used as well"""
         self.settings[ctx.message.server.id]['defualt_name'] = defualt_name
-        await self.say("Default channel name set to `{0}`!".format(defualt_name))
+        await self.bot.say("Default channel name set to `{0}`!".format(defualt_name))
     
     #Voice command
     @commands.command(pass_context=True)
@@ -315,7 +315,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
 
-            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author, ctx=ctx), perms, type=discord.ChannelType.voice)#creates a channel           
+            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author), perms, type=discord.ChannelType.voice)#creates a channel           
             
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -361,7 +361,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json",self.check_empty)# saves new list
             await asyncio.sleep(DELAY)
 
-        await self.bot.send_message(discord.Appinfo.owner, "Channels will no longer be deleted! An issue has ocurred. some INFO: `self.check_empty: {0} | self.bot.get_cog: {1}`".format(self.check_empty, self.bot.get_cog("TempVoice")))
+        await self.bot.send_message(discord.AppInfo.owner, "Channels will no longer be deleted! An issue has ocurred. some INFO: `self.check_empty: {0} | self.bot.get_cog: {1}`".format(self.check_empty, self.bot.get_cog("TempVoice")))
         #Some instances have issues here (not sure why still)
 
 def check_folders(): #Creates a folder

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -245,6 +245,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
                 dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file
 
                 await asyncio.sleep(1)
+                await self.channel_to_category(user.voice_channel.id, channel.id) #puts channel into the right category                
                 await self.bot.move_member(user, channel)
                 await self.bot.move_channel(channel, position+1)
                     

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -178,6 +178,16 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
 
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)                  
     
+    @VoiceSet.command(name="name", pass_context=True)
+    @checks.serverowner_or_permissions(manage_channels=True)
+    async def voice_set_default(self,ctx,*,defualt_name="{user.name}")
+        """sets the default channel name, resets with no parameters
+        Allows for {user.name} for their name
+        {user.game} for their currently playing status
+        Many other values of user can be used as well"""
+        self.settings[ctx.message.server]['defualt_name'] = defualt_name
+        await self.say("Default channel name set to `{0}`!".format(defualt_name))
+    
     #Voice command
     @commands.command(pass_context=True)
     @commands.cooldown(1, 60, commands.BucketType.user)
@@ -189,7 +199,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             return
 
         if name =='': #Tests if no name was passed
-            name = ctx.message.author.name #Sets it to the name of whoever sent the message
+            name = self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
 
         server_role = self.settings[ctx.message.server.id]['role']
         if server_role is not None:
@@ -204,7 +214,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
         
         #If all the requirements are met
         try:
-            perms = discord.PermissionOverwrite(mute_members=True, deafen_members=True, manage_channels=True)#Sets permisions
+            perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=ctx.message.author, overwrite=perms)#Sets the channel permissions for the person who sent the message
             channel = await self.bot.create_channel(ctx.message.server, name, perms, type=discord.ChannelType.voice)#creates a channel          
             
@@ -287,10 +297,10 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
                 return
             
             position = user.voice_channel.position
-            perms = discord.PermissionOverwrite(mute_members=True, deafen_members=True, manage_channels=True)#Sets permisions
+            perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
 
-            channel = await self.bot.create_channel(user.voice_channel.server, user.name, perms, type=discord.ChannelType.voice)#creates a channel           
+            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=ctx.message.author, ctx=ctx), perms, type=discord.ChannelType.voice)#creates a channel           
             
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -200,6 +200,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
         {user.game} for their currently playing status
         Many other values of user can be used as well"""
         self.settings[ctx.message.server.id]['defualt_name'] = defualt_name
+        dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
         await self.bot.say("Default channel name set to `{0}`!".format(defualt_name))
     
     #Voice command

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -191,7 +191,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
     
     @VoiceSet.command(name="name", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
-    async def voice_set_default(self,ctx,*,defualt_name="{user.nick}")
+    async def voice_set_default(self,ctx,*,defualt_name:str="{user.nick}")
         """sets the default channel name, resets with no parameters
         Allows for {user.name} for their name
         {user.game} for their currently playing status

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -194,10 +194,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
     @VoiceSet.command(name="name", pass_context=True)
     @checks.serverowner_or_permissions(manage_channels=True)
     async def voice_set_default(self,ctx,*,defualt_name:str="{user.nick}"):
-        """sets the default channel name, resets with no parameters
-        Allows for {user.name} for their name
-        {user.game} for their currently playing status
-        Many other values of user can be used as well"""
+        """sets the default channel name, resets with no parameters"""
         self.settings[ctx.message.server.id]['defualt_name'] = defualt_name
         dataIO.save_json("data/Tasty/TempVoice/settings.json", self.settings)
         await self.bot.say("Default channel name set to `{0}`!".format(defualt_name))
@@ -315,7 +312,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions
             perms = discord.ChannelPermissions(target=user, overwrite=perms)#Sets the channel permissions for the person who sent the message
 
-            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[ctx.message.server]['defualt_name'].format(user=user), perms, type=discord.ChannelType.voice)#creates a channel           
+            channel = await self.bot.create_channel(user.voice_channel.server, self.settings[user.voice_channel.server.id]['defualt_name'].format(user=user), perms, type=discord.ChannelType.voice)#creates a channel           
             
             self.check_empty.append(channel.id) #Multidimentional list
             dataIO.save_json("data/Tasty/TempVoice/VoiceChannel.json", self.check_empty)#saves the new file

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -210,7 +210,14 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             return
 
         if name =='': #Tests if no name was passed
-            name = self.settings[ctx.message.server.id]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
+            if ctx.message.author.nick is not None:
+                name = self.settings[ctx.message.server.id]['defualt_name'].format(user=ctx.message.author) #Sets it to the defualt name for the server
+
+            #If they do not have a nickname
+            else:
+                name = self.settings[ctx.message.server.id]['defualt_name'].replace("nick}","name}").format(user=ctx.message.author) #Sets it to the defualt name
+
+        name = name.replace("None", "Nothing") #Replaces "None" so that channel name reads better
 
         server_role = self.settings[ctx.message.server.id]['role']
         if server_role is not None:
@@ -307,6 +314,16 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
         try:
             if self.settings[user.voice_channel.server.id]['channel']!=user.voice_channel.id:
                 return
+            
+            #set the channel name
+            if user.nick is not None:
+                name = self.settings[user.voice_channel.server.id]['defualt_name'].format(user=user) #Sets it to the defualt name for the server
+
+            #If they do not have a nickname
+            else:
+                name = self.settings[user.voice_channel.server.id]['defualt_name'].replace("nick}","name}").format(user=user) #Sets it to the defualt name
+
+            name = name.replace("None", "Nothing") #Replaces "None" so that channel name reads better
             
             position = user.voice_channel.position
             perms = discord.PermissionOverwrite(manage_channels=True)#Sets permisions

--- a/tempvoice/tempvoice.py
+++ b/tempvoice/tempvoice.py
@@ -290,6 +290,7 @@ Also make sure I have "move members" and "manage channels" permissions! """, col
             'role':None,
             'channel':None,
             'type':False,
+            'category': None,
             'defualt_name':"{user.nick}"
             }
 


### PR DESCRIPTION
+ rolenotifier
   Changed commands to one command with sub commands
   (To add a new notification it is now [p]setroles add <role_name> <Notification_message>)
   Sub commands are now; add, remove and list
   gives option when adding a role if it is to **not** be sent though direct message (default is though direct message)
   Lots of other small improvements

+ tempvoice
   now allows server admins to customise the default name of the voice channel